### PR TITLE
defined AntPathMatcher bean

### DIFF
--- a/src/main/java/com/desiato/puresynth/configurations/ProjectConfig.java
+++ b/src/main/java/com/desiato/puresynth/configurations/ProjectConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.AntPathMatcher;
 
 @Configuration
 public class ProjectConfig {
@@ -11,6 +12,11 @@ public class ProjectConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AntPathMatcher antPathMatcher() {
+        return new AntPathMatcher();
     }
 
 }


### PR DESCRIPTION
## What?
Defined an `AntPathMatcher` Bean in the Project Configuration class.

## Why?
The Spring context was unable to find a bean of type `org.springframework.util.AntPathMatcher`, causing the application to fail during startup.