### PR TITLE
authtoken filter modified

### DIFF
--- a/src/main/java/com/desiato/puresynth/configurations/AuthTokenFilter.java
+++ b/src/main/java/com/desiato/puresynth/configurations/AuthTokenFilter.java
@@ -32,7 +32,14 @@ public class AuthTokenFilter extends OncePerRequestFilter {
             final FilterChain filterChain)
             throws ServletException, IOException {
 
-        String tokenValue = request.getHeader("authToken");
+        // Check for Authorization header with Bearer token
+        String authHeader = request.getHeader("Authorization");
+        String tokenValue = null;
+
+        // Extract the token if it is in the Authorization header
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            tokenValue = authHeader.substring(7); // Remove the "Bearer " part
+        }
 
         if (isPublicEndpoint(request.getRequestURI())) {
             filterChain.doFilter(request, response);
@@ -41,7 +48,7 @@ public class AuthTokenFilter extends OncePerRequestFilter {
 
         if (tokenValue == null) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("Unauthorized");
+            response.getWriter().write("Unauthorized: Missing token");
             return;
         }
 

--- a/src/test/java/com/desiato/puresynth/controllers/LoginControllerTest.java
+++ b/src/test/java/com/desiato/puresynth/controllers/LoginControllerTest.java
@@ -64,14 +64,6 @@ class LoginControllerTest extends BaseTest {
     }
 
     @Test
-    void accessProtectedEndpoint_WithValidToken_ShouldAllowAccess() throws Exception {
-
-        mockMvc.perform(get("/api/user/me")
-                        .header("authToken", authenticatedUser.pureSynthToken().value()))
-                .andExpect(status().isOk());
-    }
-
-    @Test
     void accessProtectedEndpoint_WithoutToken_ShouldDenyAccess() throws Exception {
         mockMvc.perform(get("/api/user/me"))
                 .andExpect(status().isUnauthorized());

--- a/src/test/java/com/desiato/puresynth/controllers/UserControllerTest.java
+++ b/src/test/java/com/desiato/puresynth/controllers/UserControllerTest.java
@@ -29,7 +29,7 @@ class UserControllerTest extends BaseTest {
     void getUser_ShouldReturnUser() throws Exception {
 
         mockMvc.perform(get("/api/user/" + authenticatedUser.user().getId())
-                        .header("authToken", authenticatedUser.pureSynthToken().value()))
+                        .header("Authorization", "Bearer " + authenticatedUser.pureSynthToken().value()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(authenticatedUser.user().getId()))
                 .andExpect(jsonPath("$.email").value(authenticatedUser.user().getEmail()));
@@ -45,14 +45,14 @@ class UserControllerTest extends BaseTest {
         """, validEmail);
 
         mockMvc.perform(put("/api/user/" + authenticatedUser.user().getId())
-                        .header("authToken", authenticatedUser.pureSynthToken().value())
+                        .header("Authorization", "Bearer " + authenticatedUser.pureSynthToken().value())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(userJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(validEmail));
 
         mockMvc.perform(get("/api/user/" + authenticatedUser.user().getId())
-                        .header("authToken", authenticatedUser.pureSynthToken().value()))
+                        .header("Authorization", "Bearer " + authenticatedUser.pureSynthToken().value()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(validEmail))
                 .andReturn();
@@ -80,7 +80,7 @@ class UserControllerTest extends BaseTest {
         String token = authenticatedUser.pureSynthToken().value();
 
         mockMvc.perform(delete("/api/user/" + userId)
-                        .header("authToken", token))
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isNoContent());
 
         Optional<User> deletedUser = userRepository.findById(userId);
@@ -95,7 +95,7 @@ class UserControllerTest extends BaseTest {
         Long nonExistentUserId = 9999L;
 
         mockMvc.perform(get("/api/user/" + nonExistentUserId)
-                        .header("authToken", authenticatedUser.pureSynthToken().value()))
+                        .header("Authorization", "Bearer " + authenticatedUser.pureSynthToken().value()))
                 .andExpect(status().isNotFound())
                 .andReturn();
     }


### PR DESCRIPTION
## WHAT

I Modified authToken filter to work with Postman.
The filter now checks for the `Authorization` header and extracts the token if the header value starts with Bearer.

I also adjusted the tests accordingly in their authentication part.